### PR TITLE
Redundant values in shorthand properties

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
   <!-- User-overrideable properties                                      -->
   <!-- =================================================================== -->
 
-  <property name="servlet.lib" value="/usr/share/java/servlet-2.3.jar"/>
+  <property name="servlet.lib" value="/opt/tomcat/lib/servlet-api.jar"/>
 
   <!-- =================================================================== -->
   <!-- Project-wide properties                                           -->

--- a/org/w3c/css/properties/css1/Css1Style.java
+++ b/org/w3c/css/properties/css1/Css1Style.java
@@ -941,7 +941,7 @@ public class Css1Style extends CssStyle {
 					"no-background-color", 2, emptyArray, ac));
 		}
 
-		// now testing for % and length in padding and marging
+		// now testing for % and length in padding and margin
 
 		RelativeAndAbsolute checker = new RelativeAndAbsolute();
 		CssProperty info = null;

--- a/org/w3c/css/properties/css1/CssBorderColor.java
+++ b/org/w3c/css/properties/css1/CssBorderColor.java
@@ -113,17 +113,38 @@ public class CssBorderColor extends org.w3c.css.properties.css.CssBorderColor {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-color: red red green green; }
+				// .no-warning { border-color: red red red green; }
+				// .no-warning { border-color: red green green red; }
+				// .no-warning { border-color: red green blue red; }
+				// .no-warning { border-color: red green green blue; }
+				// .no-warning { border-color: red green blue blue; }
+				// .no-warning { border-color: red green blue black; }
+				// .warning { border-color: red red red red; }
+				// .warning { border-color: red green red green; }
+				// .warning { border-color: red green green green; }
+				// .warning { border-color: red green blue green; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css1/CssBorderStyle.java
+++ b/org/w3c/css/properties/css1/CssBorderStyle.java
@@ -132,17 +132,38 @@ public class CssBorderStyle extends org.w3c.css.properties.css.CssBorderStyle {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-style: dotted dotted dashed dashed; }
+				// .no-warning { border-style: dotted dotted dotted dashed; }
+				// .no-warning { border-style: dotted dashed dashed dotted; }
+				// .no-warning { border-style: dotted dashed solid dotted; }
+				// .no-warning { border-style: dotted dashed dashed solid; }
+				// .no-warning { border-style: dotted dashed solid solid; }
+				// .no-warning { border-style: dotted dashed solid double; }
+				// .warning { border-style: dotted dotted dotted dotted; }
+				// .warning { border-style: dotted dashed dotted dashed; }
+				// .warning { border-style: dotted dashed dashed dashed; }
+				// .warning { border-style: dotted dashed solid dashed; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css1/CssBorderWidth.java
+++ b/org/w3c/css/properties/css1/CssBorderWidth.java
@@ -135,17 +135,38 @@ public class CssBorderWidth extends org.w3c.css.properties.css.CssBorderWidth {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-width: 1px 1px 2px 2px; }
+				// .no-warning { border-width: 1px 1px 1px 2px; }
+				// .no-warning { border-width: 1px 2px 2px 1px; }
+				// .no-warning { border-width: 1px 2px 3px 1px; }
+				// .no-warning { border-width: 1px 2px 2px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 4px; }
+				// .warning { border-width: 1px 1px 1px 1px; }
+				// .warning { border-width: 1px 2px 1px 2px; }
+				// .warning { border-width: 1px 2px 2px 2px; }
+				// .warning { border-width: 1px 2px 3px 2px; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css1/CssMargin.java
+++ b/org/w3c/css/properties/css1/CssMargin.java
@@ -108,18 +108,34 @@ public class CssMargin extends org.w3c.css.properties.css.CssMargin {
 				marginRight.value = v.get(1);
 				marginBottom.value = v.get(0);
 				marginLeft.value = v.get(1);
+				if (v.get(0).equals(v.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			case 3:
 				marginTop.value = v.get(0);
 				marginRight.value = v.get(1);
 				marginBottom.value = v.get(2);
 				marginLeft.value = v.get(1);
+				if (v.get(0).equals(v.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			case 4:
 				marginTop.value = v.get(0);
 				marginRight.value = v.get(1);
 				marginBottom.value = v.get(2);
 				marginLeft.value = v.get(3);
+				
+				if (v.get(0).equals(v.get(2)) || v.get(1).equals(v.get(3))) {
+					// margin: 1px 1px 1px 1px;
+					// margin: 1px 2px 1px 2px;
+					// margin: 1px 2px 3px 2px;
+					// margin: 1px 2px 1px 3px;
+					// margin: 1px 2px 2px 2px;
+					// margin: 2px 2px 2px 1px;
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			default:
 				// can't happen unless we are not checking

--- a/org/w3c/css/properties/css1/CssMargin.java
+++ b/org/w3c/css/properties/css1/CssMargin.java
@@ -126,14 +126,19 @@ public class CssMargin extends org.w3c.css.properties.css.CssMargin {
 				marginRight.value = v.get(1);
 				marginBottom.value = v.get(2);
 				marginLeft.value = v.get(3);
-				
-				if (v.get(0).equals(v.get(2)) || v.get(1).equals(v.get(3))) {
-					// margin: 1px 1px 1px 1px;
-					// margin: 1px 2px 1px 2px;
-					// margin: 1px 2px 3px 2px;
-					// margin: 1px 2px 1px 3px;
-					// margin: 1px 2px 2px 2px;
-					// margin: 2px 2px 2px 1px;
+
+				// .no-warning { margin: 1px 1px 2px 2px; }
+				// .no-warning { margin: 1px 1px 1px 2px; }
+				// .no-warning { margin: 1px 2px 2px 1px; }
+				// .no-warning { margin: 1px 2px 3px 1px; }
+				// .no-warning { margin: 1px 2px 2px 3px; }
+				// .no-warning { margin: 1px 2px 3px 3px; }
+				// .no-warning { margin: 1px 2px 3px 4px; }
+				// .warning { margin: 1px 1px 1px 1px; }
+				// .warning { margin: 1px 2px 1px 2px; }
+				// .warning { margin: 1px 2px 2px 2px; }
+				// .warning { margin: 1px 2px 3px 2px; }
+				if (v.get(1).equals(v.get(3))) {
 					ac.getFrame().addWarning("shorthand-redundant", 2);
 				}
 				break;

--- a/org/w3c/css/properties/css1/CssPadding.java
+++ b/org/w3c/css/properties/css1/CssPadding.java
@@ -103,18 +103,39 @@ public class CssPadding extends org.w3c.css.properties.css.CssPadding {
 				paddingRight.value = v.get(1);
 				paddingBottom.value = v.get(0);
 				paddingLeft.value = v.get(1);
+				if (v.get(0).equals(v.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			case 3:
 				paddingTop.value = v.get(0);
 				paddingRight.value = v.get(1);
 				paddingBottom.value = v.get(2);
 				paddingLeft.value = v.get(1);
+				if (v.get(0).equals(v.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			case 4:
 				paddingTop.value = v.get(0);
 				paddingRight.value = v.get(1);
 				paddingBottom.value = v.get(2);
 				paddingLeft.value = v.get(3);
+				
+				// .no-warning { padding: 1px 1px 2px 2px; }
+				// .no-warning { padding: 1px 1px 1px 2px; }
+				// .no-warning { padding: 1px 2px 2px 1px; }
+				// .no-warning { padding: 1px 2px 3px 1px; }
+				// .no-warning { padding: 1px 2px 2px 3px; }
+				// .no-warning { padding: 1px 2px 3px 3px; }
+				// .no-warning { padding: 1px 2px 3px 4px; }
+				// .warning { padding: 1px 1px 1px 1px; }
+				// .warning { padding: 1px 2px 1px 2px; }
+				// .warning { padding: 1px 2px 2px 2px; }
+				// .warning { padding: 1px 2px 3px 2px; }
+				if (v.get(1).equals(v.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			default:
 				// can't happen unless we are not checking

--- a/org/w3c/css/properties/css2/CssBorderColor.java
+++ b/org/w3c/css/properties/css2/CssBorderColor.java
@@ -112,17 +112,38 @@ public class CssBorderColor extends org.w3c.css.properties.css.CssBorderColor {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-color: red red green green; }
+				// .no-warning { border-color: red red red green; }
+				// .no-warning { border-color: red green green red; }
+				// .no-warning { border-color: red green blue red; }
+				// .no-warning { border-color: red green green blue; }
+				// .no-warning { border-color: red green blue blue; }
+				// .no-warning { border-color: red green blue black; }
+				// .warning { border-color: red red red red; }
+				// .warning { border-color: red green red green; }
+				// .warning { border-color: red green green green; }
+				// .warning { border-color: red green blue green; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css2/CssBorderStyle.java
+++ b/org/w3c/css/properties/css2/CssBorderStyle.java
@@ -128,17 +128,38 @@ public class CssBorderStyle extends org.w3c.css.properties.css.CssBorderStyle {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-style: dotted dotted dashed dashed; }
+				// .no-warning { border-style: dotted dotted dotted dashed; }
+				// .no-warning { border-style: dotted dashed dashed dotted; }
+				// .no-warning { border-style: dotted dashed solid dotted; }
+				// .no-warning { border-style: dotted dashed dashed solid; }
+				// .no-warning { border-style: dotted dashed solid solid; }
+				// .no-warning { border-style: dotted dashed solid double; }
+				// .warning { border-style: dotted dotted dotted dotted; }
+				// .warning { border-style: dotted dashed dotted dashed; }
+				// .warning { border-style: dotted dashed dashed dashed; }
+				// .warning { border-style: dotted dashed solid dashed; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css2/CssBorderWidth.java
+++ b/org/w3c/css/properties/css2/CssBorderWidth.java
@@ -139,17 +139,38 @@ public class CssBorderWidth extends org.w3c.css.properties.css.CssBorderWidth {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-width: 1px 1px 2px 2px; }
+				// .no-warning { border-width: 1px 1px 1px 2px; }
+				// .no-warning { border-width: 1px 2px 2px 1px; }
+				// .no-warning { border-width: 1px 2px 3px 1px; }
+				// .no-warning { border-width: 1px 2px 2px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 4px; }
+				// .warning { border-width: 1px 1px 1px 1px; }
+				// .warning { border-width: 1px 2px 1px 2px; }
+				// .warning { border-width: 1px 2px 2px 2px; }
+				// .warning { border-width: 1px 2px 3px 2px; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css2/CssPadding.java
+++ b/org/w3c/css/properties/css2/CssPadding.java
@@ -126,18 +126,39 @@ public class CssPadding extends org.w3c.css.properties.css.CssPadding {
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(0);
 					paddingLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(1))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 3:
 					paddingTop.value = v.get(0);
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(2);
 					paddingLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(2))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 4:
 					paddingTop.value = v.get(0);
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(2);
 					paddingLeft.value = v.get(3);
+					
+					// .no-warning { padding: 1px 1px 2px 2px; }
+					// .no-warning { padding: 1px 1px 1px 2px; }
+					// .no-warning { padding: 1px 2px 2px 1px; }
+					// .no-warning { padding: 1px 2px 3px 1px; }
+					// .no-warning { padding: 1px 2px 2px 3px; }
+					// .no-warning { padding: 1px 2px 3px 3px; }
+					// .no-warning { padding: 1px 2px 3px 4px; }
+					// .warning { padding: 1px 1px 1px 1px; }
+					// .warning { padding: 1px 2px 1px 2px; }
+					// .warning { padding: 1px 2px 2px 2px; }
+					// .warning { padding: 1px 2px 3px 2px; }
+					if (v.get(1).equals(v.get(3))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				default:
 					// can't happen unless we are not checking

--- a/org/w3c/css/properties/css21/CssBorderColor.java
+++ b/org/w3c/css/properties/css21/CssBorderColor.java
@@ -113,17 +113,38 @@ public class CssBorderColor extends org.w3c.css.properties.css.CssBorderColor {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-color: red red green green; }
+				// .no-warning { border-color: red red red green; }
+				// .no-warning { border-color: red green green red; }
+				// .no-warning { border-color: red green blue red; }
+				// .no-warning { border-color: red green green blue; }
+				// .no-warning { border-color: red green blue blue; }
+				// .no-warning { border-color: red green blue black; }
+				// .warning { border-color: red red red red; }
+				// .warning { border-color: red green red green; }
+				// .warning { border-color: red green green green; }
+				// .warning { border-color: red green blue green; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css21/CssBorderStyle.java
+++ b/org/w3c/css/properties/css21/CssBorderStyle.java
@@ -128,17 +128,38 @@ public class CssBorderStyle extends org.w3c.css.properties.css.CssBorderStyle {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-style: dotted dotted dashed dashed; }
+				// .no-warning { border-style: dotted dotted dotted dashed; }
+				// .no-warning { border-style: dotted dashed dashed dotted; }
+				// .no-warning { border-style: dotted dashed solid dotted; }
+				// .no-warning { border-style: dotted dashed dashed solid; }
+				// .no-warning { border-style: dotted dashed solid solid; }
+				// .no-warning { border-style: dotted dashed solid double; }
+				// .warning { border-style: dotted dotted dotted dotted; }
+				// .warning { border-style: dotted dashed dotted dashed; }
+				// .warning { border-style: dotted dashed dashed dashed; }
+				// .warning { border-style: dotted dashed solid dashed; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css21/CssBorderWidth.java
+++ b/org/w3c/css/properties/css21/CssBorderWidth.java
@@ -139,17 +139,38 @@ public class CssBorderWidth extends org.w3c.css.properties.css.CssBorderWidth {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-width: 1px 1px 2px 2px; }
+				// .no-warning { border-width: 1px 1px 1px 2px; }
+				// .no-warning { border-width: 1px 2px 2px 1px; }
+				// .no-warning { border-width: 1px 2px 3px 1px; }
+				// .no-warning { border-width: 1px 2px 2px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 4px; }
+				// .warning { border-width: 1px 1px 1px 1px; }
+				// .warning { border-width: 1px 2px 1px 2px; }
+				// .warning { border-width: 1px 2px 2px 2px; }
+				// .warning { border-width: 1px 2px 3px 2px; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css21/CssMargin.java
+++ b/org/w3c/css/properties/css21/CssMargin.java
@@ -145,13 +145,18 @@ public class CssMargin extends org.w3c.css.properties.css.CssMargin {
 					marginBottom.value = v.get(2);
 					marginLeft.value = v.get(3);
 
-					if (v.get(0).equals(v.get(2)) || v.get(1).equals(v.get(3))) {
-						// margin: 1px 1px 1px 1px;
-						// margin: 1px 2px 1px 2px;
-						// margin: 1px 2px 3px 2px;
-						// margin: 1px 2px 1px 3px;
-						// margin: 1px 2px 2px 2px;
-						// margin: 2px 2px 2px 1px;
+					// .no-warning { margin: 1px 1px 2px 2px; }
+					// .no-warning { margin: 1px 1px 1px 2px; }
+					// .no-warning { margin: 1px 2px 2px 1px; }
+					// .no-warning { margin: 1px 2px 3px 1px; }
+					// .no-warning { margin: 1px 2px 2px 3px; }
+					// .no-warning { margin: 1px 2px 3px 3px; }
+					// .no-warning { margin: 1px 2px 3px 4px; }
+					// .warning { margin: 1px 1px 1px 1px; }
+					// .warning { margin: 1px 2px 1px 2px; }
+					// .warning { margin: 1px 2px 2px 2px; }
+					// .warning { margin: 1px 2px 3px 2px; }
+					if (v.get(1).equals(v.get(3))) {
 						ac.getFrame().addWarning("shorthand-redundant", 2);
 					}
 					break;

--- a/org/w3c/css/properties/css21/CssMargin.java
+++ b/org/w3c/css/properties/css21/CssMargin.java
@@ -126,18 +126,34 @@ public class CssMargin extends org.w3c.css.properties.css.CssMargin {
 					marginRight.value = v.get(1);
 					marginBottom.value = v.get(0);
 					marginLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(1))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 3:
 					marginTop.value = v.get(0);
 					marginRight.value = v.get(1);
 					marginBottom.value = v.get(2);
 					marginLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(2))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 4:
 					marginTop.value = v.get(0);
 					marginRight.value = v.get(1);
 					marginBottom.value = v.get(2);
 					marginLeft.value = v.get(3);
+
+					if (v.get(0).equals(v.get(2)) || v.get(1).equals(v.get(3))) {
+						// margin: 1px 1px 1px 1px;
+						// margin: 1px 2px 1px 2px;
+						// margin: 1px 2px 3px 2px;
+						// margin: 1px 2px 1px 3px;
+						// margin: 1px 2px 2px 2px;
+						// margin: 2px 2px 2px 1px;
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				default:
 					// can't happen unless we are not checking

--- a/org/w3c/css/properties/css21/CssPadding.java
+++ b/org/w3c/css/properties/css21/CssPadding.java
@@ -126,18 +126,39 @@ public class CssPadding extends org.w3c.css.properties.css.CssPadding {
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(0);
 					paddingLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(1))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 3:
 					paddingTop.value = v.get(0);
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(2);
 					paddingLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(2))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 4:
 					paddingTop.value = v.get(0);
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(2);
 					paddingLeft.value = v.get(3);
+					
+					// .no-warning { padding: 1px 1px 2px 2px; }
+					// .no-warning { padding: 1px 1px 1px 2px; }
+					// .no-warning { padding: 1px 2px 2px 1px; }
+					// .no-warning { padding: 1px 2px 3px 1px; }
+					// .no-warning { padding: 1px 2px 2px 3px; }
+					// .no-warning { padding: 1px 2px 3px 3px; }
+					// .no-warning { padding: 1px 2px 3px 4px; }
+					// .warning { padding: 1px 1px 1px 1px; }
+					// .warning { padding: 1px 2px 1px 2px; }
+					// .warning { padding: 1px 2px 2px 2px; }
+					// .warning { padding: 1px 2px 3px 2px; }
+					if (v.get(1).equals(v.get(3))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				default:
 					// can't happen unless we are not checking

--- a/org/w3c/css/properties/css3/CssBorderColor.java
+++ b/org/w3c/css/properties/css3/CssBorderColor.java
@@ -110,17 +110,38 @@ public class CssBorderColor extends org.w3c.css.properties.css.CssBorderColor {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-color: red red green green; }
+				// .no-warning { border-color: red red red green; }
+				// .no-warning { border-color: red green green red; }
+				// .no-warning { border-color: red green blue red; }
+				// .no-warning { border-color: red green green blue; }
+				// .no-warning { border-color: red green blue blue; }
+				// .no-warning { border-color: red green blue black; }
+				// .warning { border-color: red red red red; }
+				// .warning { border-color: red green red green; }
+				// .warning { border-color: red green green green; }
+				// .warning { border-color: red green blue green; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css3/CssBorderStyle.java
+++ b/org/w3c/css/properties/css3/CssBorderStyle.java
@@ -133,17 +133,38 @@ public class CssBorderStyle extends org.w3c.css.properties.css.CssBorderStyle {
             case 2:
                 top.value = bottom.value = res.get(0);
                 right.value = left.value = res.get(1);
+                if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 3:
                 top.value = res.get(0);
                 right.value = left.value = res.get(1);
                 bottom.value = res.get(2);
+                if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             case 4:
                 top.value = res.get(0);
                 right.value = res.get(1);
                 bottom.value = res.get(2);
                 left.value = res.get(3);
+                
+                // .no-warning { border-style: dotted dotted dashed dashed; }
+				// .no-warning { border-style: dotted dotted dotted dashed; }
+				// .no-warning { border-style: dotted dashed dashed dotted; }
+				// .no-warning { border-style: dotted dashed solid dotted; }
+				// .no-warning { border-style: dotted dashed dashed solid; }
+				// .no-warning { border-style: dotted dashed solid solid; }
+				// .no-warning { border-style: dotted dashed solid double; }
+				// .warning { border-style: dotted dotted dotted dotted; }
+				// .warning { border-style: dotted dashed dotted dashed; }
+				// .warning { border-style: dotted dashed dashed dashed; }
+				// .warning { border-style: dotted dashed solid dashed; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
                 break;
             default:
                 // can't happen

--- a/org/w3c/css/properties/css3/CssBorderWidth.java
+++ b/org/w3c/css/properties/css3/CssBorderWidth.java
@@ -142,17 +142,38 @@ public class CssBorderWidth extends org.w3c.css.properties.css.CssBorderWidth {
 			case 2:
 				top.value = bottom.value = res.get(0);
 				right.value = left.value = res.get(1);
+				if (res.get(0).equals(res.get(1))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			case 3:
 				top.value = res.get(0);
 				right.value = left.value = res.get(1);
 				bottom.value = res.get(2);
+				if (res.get(0).equals(res.get(2))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			case 4:
 				top.value = res.get(0);
 				right.value = res.get(1);
 				bottom.value = res.get(2);
 				left.value = res.get(3);
+				
+				// .no-warning { border-width: 1px 1px 2px 2px; }
+				// .no-warning { border-width: 1px 1px 1px 2px; }
+				// .no-warning { border-width: 1px 2px 2px 1px; }
+				// .no-warning { border-width: 1px 2px 3px 1px; }
+				// .no-warning { border-width: 1px 2px 2px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 3px; }
+				// .no-warning { border-width: 1px 2px 3px 4px; }
+				// .warning { border-width: 1px 1px 1px 1px; }
+				// .warning { border-width: 1px 2px 1px 2px; }
+				// .warning { border-width: 1px 2px 2px 2px; }
+				// .warning { border-width: 1px 2px 3px 2px; }
+				if (res.get(1).equals(res.get(3))) {
+					ac.getFrame().addWarning("shorthand-redundant", 2);
+				}
 				break;
 			default:
 				// can't happen

--- a/org/w3c/css/properties/css3/CssMargin.java
+++ b/org/w3c/css/properties/css3/CssMargin.java
@@ -130,18 +130,34 @@ public class CssMargin extends org.w3c.css.properties.css.CssMargin {
 					marginRight.value = v.get(1);
 					marginBottom.value = v.get(0);
 					marginLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(1))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 3:
 					marginTop.value = v.get(0);
 					marginRight.value = v.get(1);
 					marginBottom.value = v.get(2);
 					marginLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(2))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 4:
 					marginTop.value = v.get(0);
 					marginRight.value = v.get(1);
 					marginBottom.value = v.get(2);
 					marginLeft.value = v.get(3);
+					
+					if (v.get(0).equals(v.get(2)) || v.get(1).equals(v.get(3))) {
+						// margin: 1px 1px 1px 1px;
+						// margin: 1px 2px 1px 2px;
+						// margin: 1px 2px 3px 2px;
+						// margin: 1px 2px 1px 3px;
+						// margin: 1px 2px 2px 2px;
+						// margin: 2px 2px 2px 1px;
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				default:
 					// can't happen unless we are not checking

--- a/org/w3c/css/properties/css3/CssMargin.java
+++ b/org/w3c/css/properties/css3/CssMargin.java
@@ -149,13 +149,18 @@ public class CssMargin extends org.w3c.css.properties.css.CssMargin {
 					marginBottom.value = v.get(2);
 					marginLeft.value = v.get(3);
 					
-					if (v.get(0).equals(v.get(2)) || v.get(1).equals(v.get(3))) {
-						// margin: 1px 1px 1px 1px;
-						// margin: 1px 2px 1px 2px;
-						// margin: 1px 2px 3px 2px;
-						// margin: 1px 2px 1px 3px;
-						// margin: 1px 2px 2px 2px;
-						// margin: 2px 2px 2px 1px;
+					// .no-warning { margin: 1px 1px 2px 2px; }
+					// .no-warning { margin: 1px 1px 1px 2px; }
+					// .no-warning { margin: 1px 2px 2px 1px; }
+					// .no-warning { margin: 1px 2px 3px 1px; }
+					// .no-warning { margin: 1px 2px 2px 3px; }
+					// .no-warning { margin: 1px 2px 3px 3px; }
+					// .no-warning { margin: 1px 2px 3px 4px; }
+					// .warning { margin: 1px 1px 1px 1px; }
+					// .warning { margin: 1px 2px 1px 2px; }
+					// .warning { margin: 1px 2px 2px 2px; }
+					// .warning { margin: 1px 2px 3px 2px; }
+					if (v.get(1).equals(v.get(3))) {
 						ac.getFrame().addWarning("shorthand-redundant", 2);
 					}
 					break;

--- a/org/w3c/css/properties/css3/CssPadding.java
+++ b/org/w3c/css/properties/css3/CssPadding.java
@@ -129,18 +129,39 @@ public class CssPadding extends org.w3c.css.properties.css.CssPadding {
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(0);
 					paddingLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(1))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 3:
 					paddingTop.value = v.get(0);
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(2);
 					paddingLeft.value = v.get(1);
+					if (v.get(0).equals(v.get(2))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				case 4:
 					paddingTop.value = v.get(0);
 					paddingRight.value = v.get(1);
 					paddingBottom.value = v.get(2);
 					paddingLeft.value = v.get(3);
+					
+					// .no-warning { padding: 1px 1px 2px 2px; }
+					// .no-warning { padding: 1px 1px 1px 2px; }
+					// .no-warning { padding: 1px 2px 2px 1px; }
+					// .no-warning { padding: 1px 2px 3px 1px; }
+					// .no-warning { padding: 1px 2px 2px 3px; }
+					// .no-warning { padding: 1px 2px 3px 3px; }
+					// .no-warning { padding: 1px 2px 3px 4px; }
+					// .warning { padding: 1px 1px 1px 1px; }
+					// .warning { padding: 1px 2px 1px 2px; }
+					// .warning { padding: 1px 2px 2px 2px; }
+					// .warning { padding: 1px 2px 3px 2px; }
+					if (v.get(1).equals(v.get(3))) {
+						ac.getFrame().addWarning("shorthand-redundant", 2);
+					}
 					break;
 				default:
 					// can't happen unless we are not checking

--- a/org/w3c/css/util/Messages.properties.en
+++ b/org/w3c/css/util/Messages.properties.en
@@ -426,3 +426,7 @@ error.incompatibletypes: The types are incompatible
 error.invalidtype: Invalid type: %s
 error.typevaluemismatch: The value %s is incompatible with its type definition <%s>
 
+# shorthand
+
+warning.shorthand-redundant: You have some redundant values in shorthand properties.
+


### PR DESCRIPTION
Hi @ylafon I added the ability to check redundant values in shorthand properties, for my own use. For example, `.abc { margin: 1px 1px 1px 1px; }` will emit a warning, but `.abc { margin: 1px; }` won't. Is it a useful feature for the official CSS Validator? If so, I'd be glad to submit a pull request to w3c/css-validator.